### PR TITLE
Fix/3.0.x/plf 3225

### DIFF
--- a/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
+++ b/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
@@ -114,3 +114,9 @@ exo.chat.port=5222
 # Security domain name: This variable controls the value of "portal.container.realm" too
 # i.e: ${portal.container.realm}=${exo.security.domain}
 exo.security.domain=gatein-domain
+
+# ECMS CKEditor EnterMode & ShiftEnterMode Configuration
+wcm.ckeditor.entermode=1
+# 1 - ENTER_P
+# 2 - ENTER_BR
+# 3 - ENTER_DIV

--- a/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
+++ b/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
@@ -114,3 +114,9 @@ exo.chat.port=5222
 # Security domain name: This variable controls the value of "portal.container.realm" too
 # i.e: ${portal.container.realm}=${exo.security.domain}
 exo.security.domain=gatein-domain
+
+# ECMS CKEditor EnterMode & ShiftEnterMode Configuration
+wcm.ckeditor.entermode=1
+# 1 - ENTER_P
+# 2 - ENTER_BR
+# 3 - ENTER_DIV


### PR DESCRIPTION
...ies file to externalize enter mode in CK Editor
- Allow users to configure enter mode for CKEditor in eXoConfig.js file
- The value of this property will gotten from configuration.properties
- This patch add enter mode in CKEditor for both jboss and tomcat server
- By default, The value of wcm.ckeditor.entermode is 1 correspondence with p tag
- If user want to use br or div tag, they only need change the value to 2 or 3.
