### PR TITLE
Fix/3.5.x/plf 2822

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/application-registry-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/application-registry-configuration.xml
@@ -621,7 +621,7 @@
                       </field>
                     </object>
                   </value>
-                  <value>
+                  <!--value>
                     <object type="org.exoplatform.application.registry.Application">
                       <field name="categoryName">
                         <string>tools</string>
@@ -649,7 +649,7 @@
                         <string>Google Translate</string>
                       </field>
                     </object>
-                  </value>
+                  </value-->
                   <value>
                     <object type="org.exoplatform.application.registry.Application">
                       <field name="applicationName"><string>messageslist</string></field>


### PR DESCRIPTION
PLF-2822: Google translate gadget is not shown when dragged and dropped on the Dashboard page
