### PR TITLE
Fix/3.5.x/plf 3284

### DIFF
--- a/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
+++ b/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
@@ -106,10 +106,10 @@ commons.upgrade.Upgrade-Gadgets.enable=true
 
 #ECMS upgrade plugin
 commons.upgrade.UpgradeVotingNodeTypePlugin.enable=false
-#Introduced in 3.5.1 (ECMS-2740, ECMS-2805)
+#Introduced in 3.5.1
 commons.upgrade.FavoriteActionUpgradePlugin.enable=true
 commons.upgrade.ThumbnailNodeTypeUpgradePlugin.enable=true
-#Introduced in 3.5.2 (ECMS-1206, ECMS-2997, ECMS-3358)
+#Introduced in 3.5.2
 commons.upgrade.UpgradePublicationPublicationNodeTypePlugin.enable=true
 commons.upgrade.UpgradeUsersFolderPlugin.enable=true
 commons.upgrade.NodeTypeTemplateUpgradePlugin.enable=true
@@ -118,7 +118,7 @@ commons.upgrade.ScriptUpgradePlugin.enable=true
 commons.upgrade.SiteExplorerTemplateUpgradePlugin.enable=true
 commons.upgrade.WCMTemplateUpgradePlugin.enable=true
 commons.upgrade.UserViewUpgradePlugin.enable=true
-#Introduced in 3.5.4 (ECMS-3715)
+#Introduced in 3.5.4
 commons.upgrade.UpgradePortletPreferencesPlugin.enable=true
 
 #CS upgrade plugin
@@ -132,7 +132,7 @@ commons.upgrade.UpgradeTemplatePlugin.enable=false
 #KS forums
 commons.upgrade.UpgradeForumPlugin.enable=false
 commons.upgrade.UpgradeWikiPlugin.enable=false
-#Introduced in 3.5.4 (KS-4410)
+#Introduced in 3.5.4
 commons.upgrade.WikiPermissionRepairPlugin.enable=true
 #
 commons.upgrade.UpgradeAnswerPlugin.enable=false
@@ -144,7 +144,7 @@ commons.upgrade.Upgrade-Navigations.enable=true
 commons.upgrade.Upgrade-WCM-Contents.enable=false
 
 ## indicates the desired execution order (names of upgrade plugins separated with commas ",")
-commons.upgrade.plugins.order=UpgradeNamespaceJosPlugin,Upgrade-Gadgets,Upgrade-Navigations,Upgrade-WCM-Contents,UpgradeVotingNodeTypePlugin,FavoriteActionUpgradePlugin,ThumbnailNodeTypeUpgradePlugin,UpgradeToMOSPlugin,UpgradeTemplatePlugin,Upgrade-Spaces-Home-page,UpgradeAnswerPlugin,UpgradeWikiPlugin,WikiPermissionRepairPlugin,UpgradeForumPlugin,UpgradeCalendarPlugin,NodeTypeTemplateUpgradePlugin,QueryUpgradePlugin,ScriptUpgradePlugin,SiteExplorerTemplateUpgradePlugin,WCMTemplateUpgradePlugin,UserViewUpgradePlugin
+commons.upgrade.plugins.order=UpgradeNamespaceJosPlugin,Upgrade-Gadgets,Upgrade-Navigations,Upgrade-WCM-Contents,UpgradeVotingNodeTypePlugin,FavoriteActionUpgradePlugin,ThumbnailNodeTypeUpgradePlugin,UpgradeToMOSPlugin,UpgradeTemplatePlugin,Upgrade-Spaces-Home-page,UpgradeAnswerPlugin,UpgradeWikiPlugin,WikiPermissionRepairPlugin,UpgradeForumPlugin,UpgradeCalendarPlugin,UpgradeUsersFolderPlugin,UpgradePublicationPublicationNodeTypePlugin,NodeTypeTemplateUpgradePlugin,QueryUpgradePlugin,ScriptUpgradePlugin,SiteExplorerTemplateUpgradePlugin,WCMTemplateUpgradePlugin,UserViewUpgradePlugin,UpgradePortletPreferencesPlugin
 
 ## Proceed to the upgrade if it's first time you run this service
 commons.upgrade.proceedIfFirstRun=false

--- a/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
+++ b/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
@@ -109,10 +109,10 @@ commons.upgrade.Upgrade-Gadgets.enable=true
 
 #ECMS upgrade plugin
 commons.upgrade.UpgradeVotingNodeTypePlugin.enable=false
-#Introduced in 3.5.1 (ECMS-2740, ECMS-2805)
+#Introduced in 3.5.1
 commons.upgrade.FavoriteActionUpgradePlugin.enable=true
 commons.upgrade.ThumbnailNodeTypeUpgradePlugin.enable=true
-#Introduced in 3.5.2 (ECMS-1206, ECMS-2997, ECMS-3358)
+#Introduced in 3.5.2
 commons.upgrade.UpgradePublicationPublicationNodeTypePlugin.enable=true
 commons.upgrade.UpgradeUsersFolderPlugin.enable=true
 commons.upgrade.NodeTypeTemplateUpgradePlugin.enable=true
@@ -121,7 +121,7 @@ commons.upgrade.ScriptUpgradePlugin.enable=true
 commons.upgrade.SiteExplorerTemplateUpgradePlugin.enable=true
 commons.upgrade.WCMTemplateUpgradePlugin.enable=true
 commons.upgrade.UserViewUpgradePlugin.enable=true
-#Introduced in 3.5.4 (ECMS-3715)
+#Introduced in 3.5.4
 commons.upgrade.UpgradePortletPreferencesPlugin.enable=true
 
 #CS upgrade plugin
@@ -135,7 +135,7 @@ commons.upgrade.UpgradeTemplatePlugin.enable=false
 #KS forums
 commons.upgrade.UpgradeForumPlugin.enable=false
 commons.upgrade.UpgradeWikiPlugin.enable=false
-#Introduced in 3.5.4 (KS-4410)
+#Introduced in 3.5.4
 commons.upgrade.WikiPermissionRepairPlugin.enable=true
 #
 commons.upgrade.UpgradeAnswerPlugin.enable=false
@@ -147,7 +147,7 @@ commons.upgrade.Upgrade-Navigations.enable=true
 commons.upgrade.Upgrade-WCM-Contents.enable=false
 
 ## indicates the desired execution order (names of upgrade plugins separated with commas ",")
-commons.upgrade.plugins.order=UpgradeNamespaceJosPlugin,Upgrade-Gadgets,Upgrade-Navigations,Upgrade-WCM-Contents,UpgradeVotingNodeTypePlugin,FavoriteActionUpgradePlugin,ThumbnailNodeTypeUpgradePlugin,UpgradeToMOSPlugin,UpgradeTemplatePlugin,Upgrade-Spaces-Home-page,UpgradeAnswerPlugin,UpgradeWikiPlugin,WikiPermissionRepairPlugin,UpgradeForumPlugin,UpgradeCalendarPlugin,NodeTypeTemplateUpgradePlugin,QueryUpgradePlugin,ScriptUpgradePlugin,SiteExplorerTemplateUpgradePlugin,WCMTemplateUpgradePlugin,UserViewUpgradePlugin
+commons.upgrade.plugins.order=UpgradeNamespaceJosPlugin,Upgrade-Gadgets,Upgrade-Navigations,Upgrade-WCM-Contents,UpgradeVotingNodeTypePlugin,FavoriteActionUpgradePlugin,ThumbnailNodeTypeUpgradePlugin,UpgradeToMOSPlugin,UpgradeTemplatePlugin,Upgrade-Spaces-Home-page,UpgradeAnswerPlugin,UpgradeWikiPlugin,WikiPermissionRepairPlugin,UpgradeForumPlugin,UpgradeCalendarPlugin,UpgradeUsersFolderPlugin,UpgradePublicationPublicationNodeTypePlugin,NodeTypeTemplateUpgradePlugin,QueryUpgradePlugin,ScriptUpgradePlugin,SiteExplorerTemplateUpgradePlugin,WCMTemplateUpgradePlugin,UserViewUpgradePlugin,UpgradePortletPreferencesPlugin
 
 ## Proceed to the upgrade if it's first time you run this service
 commons.upgrade.proceedIfFirstRun=false


### PR DESCRIPTION
PLF-3284: Remove the Migration instructions from PLF 3.5
- Disable all plugins except plugins mandatory for changes since 3.5.1
- Add WikiPermissionRepairPlugin introduced by KS-4410
- Add UpgradePortletPreferencesPlugin introduced by ECMS-3715
