### PR TITLE
PLF-2910: Gadget name returned by REST API does not match

### DIFF
--- a/component/common/src/main/java/org/exoplatform/platform/common/rest/DashboardInformationRESTService.java
+++ b/component/common/src/main/java/org/exoplatform/platform/common/rest/DashboardInformationRESTService.java
@@ -254,7 +254,7 @@ public class DashboardInformationRESTService implements ResourceContainer {
   
               if(gadget != null) {
                 JsonGadgetInfo info = new JsonGadgetInfo();
-                info.setGadgetName(gadget.getName());
+                info.setGadgetName(gadget.getTitle());
                 info.setGadgetUrl(PortalContainer.getCurrentPortalContainerName() + STANDALONE_ROOT_PATH + "/" + application.getStorageId());
                 info.setGadgetIcon(gadget.getThumbnail());
                 info.setGadgetDescription(gadget.getDescription());


### PR DESCRIPTION
Fix description:
- Gadget Title will be used in REST API instead of its name.
