### PR TITLE
PLF-3388: Fix 'not override abstract method' caused by new changes in EX...

### DIFF
--- a/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/LocalGadgetImporter.java
+++ b/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/LocalGadgetImporter.java
@@ -8,6 +8,7 @@ import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.shindig.gadgets.spec.ModulePrefs;
 import org.chromattic.ext.ntdef.NTFolder;
 import org.chromattic.ext.ntdef.Resource;
 import org.exoplatform.application.gadget.EncodingDetector;
@@ -255,5 +256,10 @@ public class LocalGadgetImporter extends GadgetImporter {
       mimeType = container.getPortalContext().getMimeType(fileName);
     }
     return mimeType;
+  }
+
+  @Override
+  protected void processMetadata(ModulePrefs prefs, GadgetDefinition def) throws Exception {
+    //We store no metadata for local gadget
   }
 }


### PR DESCRIPTION
EXOGTN-1207 added a new abstract method processMetadata to the base class GadgetImporter. This pull request is to add an empty implementation of that method (same as in EXOGTN-1207's ServletLocalImporter.java) to PLF's LocalGadgetImporter (used by gadget upgrade plugin) to avoid 'not override abstract method' exception when building PLF's upgrade-plugins
