### PR TITLE
PLF-3428: Links in the gadgets of exo Social are incorrectly pointing to...

### DIFF
--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Agenda/js/tasks.js
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Agenda/js/tasks.js
@@ -151,7 +151,7 @@ eXoEventGadget.prototype.getPrefs = function(){
 //TODO: Need a new solution for creating url replace for using parent 
 eXoEventGadget.prototype.setLink = function(){
 	var url   = eXoEventGadget.prefs.url;
-	baseUrl = "http://" +  top.location.host + parent.eXo.env.portal.context + "/intranet"; //+ parent.eXo.env.portal.portalName;
+	baseUrl = "http://" +  top.location.host + parent.eXo.env.portal.context + "/" + parent.eXo.env.portal.portalName;
 	a = document.getElementById("ShowAll");
 	url = (url)?baseUrl + url: baseUrl + "/calendar";
 	a.href = url;

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Bookmark/Bookmark.xml
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Bookmark/Bookmark.xml
@@ -38,7 +38,8 @@
 
         $.getJSON("/rest/bookmarks/get", function(bookmarks){
           $.each(bookmarks, function(i, bookmark){
-            addBookmark(i, bookmark.name.replace(/__SLASH__/g, "/"), bookmark.link.replace(/__SLASH__/g, "/"));
+           var link2 = bookmark.link.replace(/__SLASH__/g, "/").replace("/$PORTAL",parent.parent.eXo.env.portal.context).replace("$SITENAME",parent.parent.eXo.env.portal.portalName);
+           addBookmark(i, bookmark.name.replace(/__SLASH__/g, "/"),link2);
           });
           gadgets.window.adjustHeight($("#content").get(0).offsetHeight);
         });

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FavoriteDocument/FavoriteDocument.xml
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FavoriteDocument/FavoriteDocument.xml
@@ -84,8 +84,7 @@
 
          //accessUrl = prefixUrl + '/portal/public/intranet/content/repository/';
 
-	accessUrl = prefixUrl + '/portal/intranet/documents';
-      /**
+		accessUrl = prefixUrl + parent.parent.eXo.env.portal.context + '/' + parent.parent.eXo.env.portal.portalName + '/documents';      /**
         * Time to refresh data in client and gadget server
         */
       var refreshInterval = 30000;

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FavoriteDocument/javascript/script.js
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FavoriteDocument/javascript/script.js
@@ -49,7 +49,7 @@ function eXoFavDocsGadget(){
 };
 
 eXoFavDocsGadget.prototype.setShowAllLink = function(){
-	var baseUrl = "http://" +  top.location.host + parent.eXo.env.portal.context + "/" + parent.eXo.env.portal.accessMode + "/intranet";
+	var baseUrl = "http://" +  top.location.host + parent.eXo.env.portal.context + "/" + parent.eXo.env.portal.accessMode + "/" + parent.eXo.env.portal.portalName";
 	a = document.getElementById("ShowAll");
 	var url = baseUrl + "/documents";
 	a.href = url;

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FeaturedPoll/script/poll.js
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/FeaturedPoll/script/poll.js
@@ -17,7 +17,7 @@ function init() {
 
 function createPollDiv() {
   var prefs = new gadgets.Prefs();
-  var forumURL = window.location.protocol + "//" + window.location.host + "/portal/intranet/forum";
+  var forumURL = window.location.protocol + "//" + window.location.host + parent.parent.eXo.env.portal.context + "/"+ parent.parent.eXo.env.portal.portalName +"/forum";
   document.getElementById("createpoll").innerHTML = "<a target='_parent' href='" + forumURL + "'>"+ prefs.getMsg("createPoll") + "</a>";
   adjustHeight();  
 }
@@ -78,7 +78,7 @@ function showPoll(data, isVoteAgain){
       if(haveTopic){
           var prefs = new gadgets.Prefs();
           var topicId= pollId.replace("poll","topic");
-          var topicURL = window.location.protocol + "//" + window.location.host + "/portal/intranet/forum/topic/" + topicId;
+          var topicURL = window.location.protocol + "//" + window.location.host + parent.parent.eXo.env.portal.context + "/"+ parent.parent.eXo.env.portal.portalName +"/forum/topic/" + topicId;
           html.push('<h4><a  target="_parent" class="Question" title = "' + prefs.getMsg('discuss') + '" target ="_parent" href="'+ topicURL + '">' + question + '</a></h4>');
         discussUrl = "<a class='Discuss' title='" + prefs.getMsg("discuss") + "'  target='_parent'  href='"+ topicURL + "'>" + prefs.getMsg("discuss") + "</a>";
       }
@@ -126,9 +126,9 @@ function showResult(data){
   var tbl = [];
   
   if(haveTopic){
-      var prefs = new gadgets.Prefs();
+    var prefs = new gadgets.Prefs();
     var topicId= pollId.replace("poll","topic");
-      var topicURL = window.location.protocol + "//" + window.location.host + "/portal/intranet/forum/topic/" + topicId;
+    var topicURL = window.location.protocol + "//" + window.location.host + parent.parent.eXo.env.portal.context + "/"+ parent.parent.eXo.env.portal.portalName + "/forum/topic/" + topicId;
     tbl.push('<h4><a class="Question" title = "' + prefs.getMsg('discuss') + '"  target="_parent"  href="'+ topicURL + '">' + question + '</a></h4>');
     discussUrl = '<a class="Discuss" title = "' + prefs.getMsg('discuss') + '"  target="_parent"  href="'+ topicURL + '">' + prefs.getMsg('discuss') + '</a>';
   }

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Invitations/Invitations.xml
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/Invitations/Invitations.xml
@@ -92,9 +92,8 @@
                 $('#connections_requests_nb').append("(" + relationRequests.length + ")");
                 $('#connections_requests_handler').empty();
                 $.each(relationRequests, function(key, relationRequest) {
-                  var contactAvatar = "<a href='/portal/intranet/profile/" + relationRequest.relationshipId + "' target='_parent'>" + "<img style='width: 24px; height: 24px; border-width: 0px;' alt='Avatar' src='" + (relationRequest.avatarUrl == null ? "/social-resources/skin/ShareImages/Avatar.gif" : relationRequest.avatarUrl) + "'>" + "</img></a>";
-                  var contactInfo = "<a href='/portal/intranet/profile/" + relationRequest.relationshipId + "' target='_parent'>" + "<strong>" + relationRequest.requesterName + "</strong>" + "</a>" +
-                                       (relationRequest.postion == null ? "" : " (" + "<span style='font-size: smaller;'>" + relationRequest.postion + "</span>" + ")") + "<br/>";
+				  var contactAvatar = "<a href='" + parent.parent.eXo.env.portal.context + "/" + parent.parent.eXo.env.portal.portalName + "/profile/" + relationRequest.relationshipId + "' target='_parent'>" + "<img style='width: 24px; height: 24px; border-width: 0px;' alt='Avatar' src='" + (relationRequest.avatarUrl == null ? "/social-resources/skin/ShareImages/Avatar.gif" : relationRequest.avatarUrl) + "'>" + "</img></a>";                  
+                  var contactInfo = "<a href='" + parent.parent.eXo.env.portal.context +"/" + parent.parent.eXo.env.portal.portalName + "/profile/" + relationRequest.relationshipId + "' target='_parent'>" + "<strong>" + relationRequest.requesterName + "</strong>" + "</a>" + (relationRequest.postion == null ? "" : " (" + "<span style='font-size: smaller;'>" + relationRequest.postion + "</span>" + ")") + "<br/>";
                   var contactRow = "<tr>" +
                                       "<td style='width: 20px;'>" + contactAvatar + "</td>" +
                                       "<td style='padding-left: 3px;'>" + contactInfo + "</td>" +
@@ -130,7 +129,7 @@
                         members = " (" + invitedSpace.members.length + " __MSG_member__)";
                   }
                   var spaceAvatar = "<img style='width: 24px; height: 24px; border-width: 0px;' src='" + (invitedSpace.avatarUrl == null ? "/social-resources/skin/ShareImages/SpaceImages/SpaceLogoDefault_61x61.gif" : invitedSpace.avatarUrl) + "' title='" + invitedSpace.description + "' alt=''>" + "</img>";
-                  var spaceInfo = "<a href='/portal/intranet/invitationSpace' target='_blank'><strong>" + invitedSpace.displayName + "</strong></a>" + members;
+                  var spaceInfo = "<a href='" + parent.parent.eXo.env.portal.context + "/" + parent.parent.eXo.env.portal.portalName + "/invitationSpace' target='_blank'><strong>" + invitedSpace.displayName + "</strong></a>" + members;                                
                                 
                   var spaceRow = "<tr>" +
                                       "<td style='width: 20px;'>" + spaceAvatar + "</td>" +
@@ -202,13 +201,19 @@
             <div id="connections_requests" class="templates requests_container">
               <table id="connections_requests_handler" style="margin-left: 10px">
               </table>
-              <div style="text-align: center; padding-top: 5px;"><a href='/portal/intranet/connections/receivedInvitations' target='_parent'>__MSG_find_more__</a></div>
+              <div style="text-align: center; padding-top: 5px;">
+              	<script>document.write('<a href ="'+parent.parent.eXo.env.portal.context + '/' + parent.parent.eXo.env.portal.portalName + '/connections/receivedInvitations "' + 'target="_parent"' + '>' + '__MSG_find_more__' + '</a>');</script>
+              </div>
             </div>
           
             <div id="space_requests" class="templates requests_container" style="display:none;">
               <table id="space_requests_handler" style="margin-left: 10px">
               </table>
-              <div style="text-align: center; padding-top: 5px;"><a href='/portal/intranet/invitationSpace' target='_parent'>__MSG_find_more__</a></div>
+              <div style="text-align: center; padding-top: 5px;">
+              	<script>
+              		document.write('<a href ="' + parent.parent.eXo.env.portal.context + '/' + parent.parent.eXo.env.portal.portalName + '/invitationSpace "' + 'target="_parent"' + '>' + '__MSG_find_more__' + '</a>');
+              	</script>
+              </div>
             </div>
         </div>
       </div>

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/MyProfile/script/profile.js
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/MyProfile/script/profile.js
@@ -23,7 +23,7 @@ function onLoadProfile(data) {
   var extensionContext = address.replace(baseContext, "");
   var extensionParts = extensionContext.split("/");
   //var context = baseContext + extensionParts[0] + "/" + extensionParts[1];
-  var context = baseContext + "intranet";
+  var context = baseContext + parent.parent.eXo.env.portal.portalName;
   var profileTempUrl = this.viewer.getField(opensocial.Person.Field.PROFILE_URL);
   var eXoUserID = profileTempUrl.substr(profileTempUrl.lastIndexOf('/') + 1);
   

--- a/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/NewSpaces/script/newSpaces.js
+++ b/samples/gadgets-sample/gadgets/src/main/webapp/gadgets/NewSpaces/script/newSpaces.js
@@ -22,12 +22,7 @@
     }
         
     eXoNewSpaceGadget.prototype.setSpaceUrl = function(){
-      var spaceURL = "";
-      if(typeof(parent.eXo) != "undefined") {
-        spaceURL = parent.eXo.env.server.context + "/" + parent.eXo.env.portal.accessMode + "/" + parent.eXo.env.portal.portalName + "/all-spaces";
-      } else {
-        spaceURL = "/portal/intranet/all-spaces";
-      }
+      var spaceURL = parent.parent.eXo.env.portal.context + "/"+ parent.parent.eXo.env.portal.portalName +"/all-spaces";
       var a = document.getElementById("ShowAll");
       a.href = spaceURL;
     }      
@@ -78,8 +73,8 @@
       var prefs = eXoNewSpaceGadget.getPrefs();
       var html = '';
       var len = spaceList.length;
-      var portalURL = window.location.protocol + "//" + window.location.host + "/portal/private/intranet/";
-      var avatarURL = window.location.protocol + "//" + window.location.host + "/portal";
+      var portalURL = window.location.protocol + "//" + window.location.host + parent.parent.eXo.env.portal.context + "/" + parent.eXo.env.portal.portalName +"/";
+      var avatarURL = window.location.protocol + "//" + window.location.host + parent.parent.eXo.env.portal.context;
 
       for(var i = 0 ; i < len; i++){  
         var item = spaceList[i];

--- a/samples/gadgets-sample/service/src/main/java/org/exoplatform/platform/gadget/services/Bookmark/BookmarkRestService.java
+++ b/samples/gadgets-sample/service/src/main/java/org/exoplatform/platform/gadget/services/Bookmark/BookmarkRestService.java
@@ -76,7 +76,7 @@ public class BookmarkRestService implements ResourceContainer {
 				Node bookmarksNode = userPrivateNode.addNode("Bookmarks");
 				userPrivateNode.save();
 
-				String default_bookmarks="[{\"name\":\"Discussions\", \"link\":\"/portal/intranet/forum\"},{\"name\":\"Wiki\", \"link\":\"/portal/intranet/wiki\"},{\"name\":\"Documents\", \"link\":\"/portal/intranet/documents\"},{\"name\":\"Agenda\", \"link\":\"/portal/intranet/calendar\"}]";
+				String default_bookmarks="[{\"name\":\"Discussions\", \"link\":\"/$PORTAL/$SITENAME/forum\"},{\"name\":\"Wiki\", \"link\":\"/$PORTAL/$SITENAME/wiki\"},{\"name\":\"Documents\", \"link\":\"/$PORTAL/$SITENAME/documents\"},{\"name\":\"Agenda\", \"link\":\"/$PORTAL/$SITENAME/calendar\"}]";
 				bookmarksNode.setProperty("exo:bookmarkService_bookmarks", default_bookmarks);
 				if(bookmarksNode.canAddMixin("exo:hiddenable")){
                     bookmarksNode.addMixin("exo:hiddenable");


### PR DESCRIPTION
- Fix May's problems concerning "private" in the link of New Space gadget.
- This fix includes also previous fixings for other gadgets.
- According to Patrice, these gadgets are made to be used in an intranet context and they make assumption about existing pages to provide they functionality. So we do not care any more about the problems when using these gadgets in ACME's dashboard. 
- We will update the docs indicating that these gadgets are meant to be used in intranet home page. Please refer to this issue : https://jira.exoplatform.org/browse/DOC-2115
