### PR TITLE
PLF-3791: Display name of tab in Dasboard page wrong when input value include some special chars

### DIFF
--- a/component/common/src/main/java/org/exoplatform/platform/common/rest/DashboardInformationRESTService.java
+++ b/component/common/src/main/java/org/exoplatform/platform/common/rest/DashboardInformationRESTService.java
@@ -151,7 +151,7 @@ public class DashboardInformationRESTService implements ResourceContainer {
   
   @GET
   @Path("/{userName}/{dashboardName}")
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces({MediaType.APPLICATION_JSON + ";charset=utf-8"})
   @SuppressWarnings("unchecked")
   public Response getGadgetInformation(@PathParam("userName") String userName, 
                                        @PathParam("dashboardName") String dashboardName,


### PR DESCRIPTION
Fix description:
    - Specify charset of Json response as utf-8
