### PR TITLE
PLF-3955: Disable some platform editions (trial, jbosseppsp, demo)

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -13,12 +13,12 @@
     <module>module</module>
     <module>product</module>
     <module>pkg</module>
-    <module>pkg-demo</module>
-    <module>pkg-trial</module>
+    <!--module>pkg-demo</module-->
+    <!--module>pkg-trial</module-->
     <module>pkg-jbosseap</module>
     <module>pkg-jboss</module>
     <module>delivery</module>
-    <module>pkg-jbossepp</module>
+    <!--module>pkg-jbossepp</module-->
     <module>source</module>
   </modules>
 </project>


### PR DESCRIPTION
Fix description:
- Remove unsupported platform editions from packaging modules
