### PR TITLE
PLF-3845: Memory Charts gadget not displayed in IE7 & IE8

### DIFF
--- a/exo-gadget-pack/gadget-pack/src/main/webapp/gadgets/Management-and-Monitoring-gadgets/Monitoring/Memory.xml
+++ b/exo-gadget-pack/gadget-pack/src/main/webapp/gadgets/Management-and-Monitoring-gadgets/Monitoring/Memory.xml
@@ -22,7 +22,7 @@
       <script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/1.6.2/jquery.min.js"></script>
       <script language="javascript" type="text/javascript" src="script/memory-utils.js"></script>
       <script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/plugins/jquery.timers/1.2/jquery.timers.js"></script>
-      <!--[if IE]><script language="javascript" type="text/javascript" src="script/excanvas.min.js"></script><![endif]-->
+      <!--[if IE]><script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/plugins/jqplot/1.0.0/excanvas.min.js"></script><![endif]-->
       <script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/plugins/jqplot/1.0.0/jquery.jqplot.min.js"></script>
       <script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/plugins/jqplot/1.0.0/plugins/jqplot.pieRenderer.min.js"></script>
       <script language="javascript" type="text/javascript" src="/exo-gadget-resources/script/jquery/plugins/jqplot/1.0.0/plugins/jqplot.highlighter.min.js"></script>


### PR DESCRIPTION
Fix description:
    - Use default ex canvas for IE 7 and IE 8 of jqplot
