### PR TITLE
PLF-4296: Wrong French label of Save button in Navigation Management form

### DIFF
--- a/component/webui/src/main/resources/groovy/platform/webui/containers/UINavigationManagement.gtmpl
+++ b/component/webui/src/main/resources/groovy/platform/webui/containers/UINavigationManagement.gtmpl
@@ -25,6 +25,6 @@
   %>
   <div class="UIAction"> 
     <a href="javascript:void(0);" onclick="<%=uicomponent.event("AddRootNode")%>" class="ActionButton LightBlueStyle"><%=_ctx.appRes(uicomponent.getId() + ".action.addNode")%></a>
-		<a href="javascript:void(0);" onclick="<%=uicomponent.event("Save")%>" class="ActionButton LightBlueStyle"><%=_ctx.appRes(uicomponent.getId() + ".action.Save")%></a>
+		<a href="javascript:void(0);" onclick="<%=uicomponent.event("Save")%>" class="ActionButton LightBlueStyle"><%=_ctx.appRes("UINavigationForm.action.Save")%></a>
 	</div>
 </div>


### PR DESCRIPTION
Fix description:
- Use static resource key to get the label
- Use the key defined in GateIn to avoid mistake
