### PR TITLE
PLF-4378: Prevent server log from long Warning message in case failed lo...

### DIFF
--- a/server/tomcat/patch/src/main/resources/conf/logging.properties
+++ b/server/tomcat/patch/src/main/resources/conf/logging.properties
@@ -113,3 +113,6 @@ org.jboss.handlers = java.util.logging.ConsoleHandler,6gatein.org.apache.juli.Fi
 
 org.apache.shindig.level = SEVERE
 org.apache.shindig.handlers = java.util.logging.ConsoleHandler,6gatein.org.apache.juli.FileHandler
+
+org.apache.catalina.realm.JAASRealm.level = SEVERE
+org.apache.catalina.realm.JAASRealm.handlers = java.util.logging.ConsoleHandler,6gatein.org.apache.juli.FileHandler


### PR DESCRIPTION
...gin

Fix description
    - Hide WARNING from JAAS if login fails
