### PR TITLE
PLF-4850: Upgrade cRaSH to 1.2.0

### DIFF
--- a/packaging/jboss-eap-ears/pom.xml
+++ b/packaging/jboss-eap-ears/pom.xml
@@ -182,6 +182,13 @@
 					  <destFileName>exo-social-extension-${org.exoplatform.social.version}.ear</destFileName>
 					  <type>ear</type>
 					</artifactItem>
+					<artifactItem>
+					  <groupId>org.crsh</groupId>
+					  <artifactId>crsh.jcr.exo</artifactId>
+					  <version>${org.crsh.version}</version>
+					  <type>war</type>
+					  <destFileName>crash.war</destFileName>
+					</artifactItem>
                                         <artifactItem>
 					  <groupId>org.exoplatform.platform</groupId>
 					  <artifactId>exo-gadget-pack-ear</artifactId>

--- a/packaging/module/src/main/javascript/platform.packaging.module.js
+++ b/packaging/module/src/main/javascript/platform.packaging.module.js
@@ -143,7 +143,7 @@ function getModule(params)
    
     // Crash
    module.crash = {};
-   module.crash.webapp = new Project("org.crsh","crsh.core", "war", crashVersion);
+   module.crash.webapp = new Project("org.crsh","crsh.jcr.exo", "war", crashVersion);
    module.crash.webapp.deployName = "crash";
    
    // eXo WebOS

--- a/packaging/tomcat/pom.xml
+++ b/packaging/tomcat/pom.xml
@@ -407,7 +407,7 @@
     <!-- Crash -->
     <dependency>
       <groupId>org.crsh</groupId>
-      <artifactId>crsh.core</artifactId>
+      <artifactId>crsh.jcr.exo</artifactId>
       <version>${org.crsh.version}</version>
       <scope>provided</scope>
       <type>war</type>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<org.exoplatform.social.version>1.2.13-SNAPSHOT</org.exoplatform.social.version>
 		<org.exoplatform.integ.version>1.0.11-SNAPSHOT</org.exoplatform.integ.version>
 		<org.exoplatform.leadcapture.version>3.4</org.exoplatform.leadcapture.version>
-		<org.crsh.version>1.0.0-beta15</org.crsh.version>
+		<org.crsh.version>1.2.1</org.crsh.version>
 		<org.exoplatform.exopackage.version>1.1.4</org.exoplatform.exopackage.version>
 		<!-- default workflow engine is bonita. Can also be jbpm -->
 		<exo.workflow.engine>jbpm</exo.workflow.engine>


### PR DESCRIPTION
Fix description:
    - Use artifact crsh.jcr.exo version 1.2.0-cr10 to packaging eXo Platform with cRash for eXo
