### PR TITLE
PLF-4918: JBoss EAP: wrong gatein folder location

### DIFF
--- a/server/jboss/patch/src/main/resources/bin/run.conf
+++ b/server/jboss/patch/src/main/resources/bin/run.conf
@@ -55,7 +55,7 @@ fi
 
 # Platform environment variables
 EXO_PROFILES="-Dexo.profiles=default"
-EXO_OPTS="-Dexo.product.developing=false -Dexo.conf.dir.name=gatein -Dgatein.data.dir=../gatein"
+EXO_OPTS="-Dexo.product.developing=false -Dexo.conf.dir.name=gatein"
 IDE_OPTS="-Djavasrc=$JAVA_HOME/src.zip -Djre.lib=$JAVA_HOME/jre/lib"
 # Declare this variable in JAVA_OPTS to run in debug mode
 REMOTE_DEBUG="-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dcom.sun.management.jmxremote -Dorg.exoplatform.container.configuration.debug"

--- a/server/jboss/patch/src/main/resources/bin/run.conf.bat
+++ b/server/jboss/patch/src/main/resources/bin/run.conf.bat
@@ -58,7 +58,7 @@ rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server
 
 rem # Platform environment variables
 set "EXO_PROFILES=-Dexo.profiles=default"
-set "EXO_OPTS=-Dexo.product.developing=false -Dexo.conf.dir.name=gatein -Dgatein.data.dir=../gatein"
+set "EXO_OPTS=-Dexo.product.developing=false -Dexo.conf.dir.name=gatein"
 set "IDE_OPTS=-Djavasrc=$JAVA_HOME/src.zip -Djre.lib=$JAVA_HOME/jre/lib"
 set "REMOTE_DEBUG=-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dcom.sun.management.jmxremote -Dorg.exoplatform.container.configuration.debug"
 rem # Here you can define your preferred xml parser - choose one or the other, or none

--- a/server/jboss/patch/src/main/resources/server/default/deploy/gatein-ds.xml
+++ b/server/jboss/patch/src/main/resources/server/default/deploy/gatein-ds.xml
@@ -25,7 +25,7 @@
 <datasources>
     <local-tx-datasource>
       <jndi-name>exo-idm_portal</jndi-name>
-      <connection-url>jdbc:hsqldb:${gatein.data.dir}/hsql/exo-idm_portal</connection-url>
+      <connection-url>jdbc:hsqldb:${jboss.server.data.dir}/gatein/hsql/exo-idm_portal</connection-url>
       <driver-class>org.hsqldb.jdbcDriver</driver-class>
       <user-name>sa</user-name>
       <password></password>
@@ -37,7 +37,7 @@
   
    <local-tx-datasource>
       <jndi-name>exo-jcr_portal</jndi-name>
-      <connection-url>jdbc:hsqldb:${gatein.data.dir}/hsql/exo-jcr_portal</connection-url>
+      <connection-url>jdbc:hsqldb:${jboss.server.data.dir}/gatein/hsql/exo-jcr_portal</connection-url>
       <driver-class>org.hsqldb.jdbcDriver</driver-class>
       <user-name>sa</user-name>
       <password></password>


### PR DESCRIPTION
Problem analysis:
	- GateIn data location depends on path from where eXo Platform jboss starts

Fix description:
	- Specify GateIn data location by data folder of jboss server