### PR TITLE
[JBoss] JS and PNG files of WAI template not available

### DIFF
--- a/extension/ear/pom.xml
+++ b/extension/ear/pom.xml
@@ -1159,7 +1159,7 @@
             <webModule>
               <groupId>org.exoplatform.ecms</groupId>
               <artifactId>exo-ecms-apps-wai-template</artifactId>
-              <contextRoot>exo-ecms-wai-template</contextRoot>
+              <contextRoot>ecm-template-waiportal</contextRoot>
               <bundleFileName>ecm-template-waiportal.war</bundleFileName>
             </webModule>
           </modules>


### PR DESCRIPTION
Problem analysis:
- The root context of the used war ecm-template-waiportal.war in platform-extension.ear/META-INF/application.xml is erroneous. 
- The used context to load the resources is ecm-template-waiportal 
