### PR TITLE
PLF-4959: Gadget Pack WAR context name different in JBoss

### DIFF
--- a/exo-gadget-pack/ear/pom.xml
+++ b/exo-gadget-pack/ear/pom.xml
@@ -56,7 +56,7 @@
             <webModule>
               <groupId>org.exoplatform.platform</groupId>
               <artifactId>gadget-pack</artifactId>
-              <contextRoot>exo-gadget-pack</contextRoot>
+              <contextRoot>gadget-pack</contextRoot>
             </webModule>
           </modules>
         </configuration>


### PR DESCRIPTION
Fix description:
    - Correct context root of Gadget Pack
