### PR TITLE
PLF-5162: Impossible to start PLF 3.5.7 with minimal startup profile

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/jcr/indexing-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/jcr/indexing-configuration.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE configuration SYSTEM "http://www.exoplatform.org/dtd/indexing-configuration-1.0.dtd">
+<configuration xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0">
+
+  <index-rule nodeType="nt:resource">
+       <property useInExcerpt="false">jcr:encoding</property>
+       <property useInExcerpt="false">jcr:mimeType</property>
+  </index-rule>
+</configuration>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/repository-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/repository-configuration.xml
@@ -76,7 +76,7 @@
               <property name="max-volatile-time" value="60" />
               <property name="support-highlighting" value="true" />
               <property name="excerptprovider-class" value="org.exoplatform.services.jcr.impl.core.query.lucene.DefaultHTMLExcerpt" />
-              <property name="indexing-configuration-path" value="war:/ks-extension/jcr/indexing-configuration.xml" />
+              <property name="indexing-configuration-path" value="war:/conf/platform/jcr/indexing-configuration.xml" />
 	      <property name="analyzer" value="org.exoplatform.services.jcr.analyzer.IgnoreAccentAnalyzer"/>
             </properties>
           </query-handler>


### PR DESCRIPTION
Problem analysis
    - Configuration in ks-extension cannot be loaded in minimal profile
    - text/html utf-8 appears in search result for a document

Fix description
    - Add index-rule parameter into platform-extension to use it in all contexts
