### PR TITLE
PLF-5222: [IE7, IE8] Cannot download document from REST service

### DIFF
--- a/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
+++ b/server/jboss/patch/src/main/resources/server/default/conf/gatein/configuration.properties
@@ -89,7 +89,7 @@ gatein.gadgets.signingkeyfile=${exo.shared.dir}/gadgets/oauthkey.pem
 # WEBDAV cache control
 # this controls the cache-control http header for WEBDAV resources by mimetype
 # wildcards (*) are allowed to match any
-exo.webdav.cache-control=text/*:max-age=3600;image/*:max-age=1800;*/*:no-cache;
+exo.webdav.cache-control=text/*:max-age=3600;image/*:max-age=1800;application/*:max-age=1800;*/*:no-cache;
 
 ############
 # Upgrades #

--- a/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
+++ b/server/tomcat/patch/src/main/resources/gatein/conf/configuration.properties
@@ -92,7 +92,7 @@ gatein.gadgets.signingkeyfile=${exo.shared.dir}/gadgets/oauthkey.pem
 # WEBDAV cache control
 # this controls the cache-control http header for WEBDAV resources by mimetype
 # wildcards (*) are allowed to match any
-exo.webdav.cache-control=text/*:max-age=3600;image/*:max-age=1800;*/*:no-cache;
+exo.webdav.cache-control=text/*:max-age=3600;image/*:max-age=1800;application/*:max-age=1800;*/*:no-cache;
 
 ############
 # Upgrades #


### PR DESCRIPTION
Problem analysis
    - Cannot use cache with document in IE7 and IE 8

Fix description
    - Use cache for all documents whose mimetype is application/*
