### PR TITLE
PLF-5210: Remove priority on the welcome-screens extension

### DIFF
--- a/welcome-screens/config/src/main/resources/conf/configuration.xml
+++ b/welcome-screens/config/src/main/resources/conf/configuration.xml
@@ -10,7 +10,6 @@
             <set-method>registerChangePlugin</set-method>
             <!-- The full qualified name of the PortalContainerDefinitionChangePlugin -->
             <type>org.exoplatform.container.definition.PortalContainerDefinitionChangePlugin</type>
-            <priority>100</priority>
             <init-params>
                 <values-param>
                     <name>default.portal.container</name>
@@ -18,17 +17,17 @@
                 </values-param>
                 <object-param>
                     <name>change</name>
-                    <object type="org.exoplatform.container.definition.PortalContainerDefinitionChange$AddDependencies">
+                    <object type="org.exoplatform.container.definition.PortalContainerDefinitionChange$AddDependenciesAfter">
                         <!-- The list of name of the dependencies to add -->
                         <field name="dependencies">
                             <collection type="java.util.ArrayList">
                                 <value>
-                                    <string>platform-extension</string>
-                                </value>
-                                <value>
                                     <string>welcome-screens</string>
                                 </value>
                             </collection>
+                        </field>
+                        <field name="target">
+                            <string>platform-extension</string>
                         </field>
                     </object>
                 </object-param>


### PR DESCRIPTION
Fix description
    - Use AddDependenciesAfter to control loading order instead of using priority
