### PR TITLE
PLF-5631 WARN Redundant resource bundle keys UIUserPlatformToolBarPortlet.label.find, UIUserNavigationPortlet.label.dashboard

### DIFF
--- a/extension/portlets/platformNavigation/src/main/webapp/groovy/platformNavigation/portlet/UIUserNavigationPortlet/UIUserNavigationPortlet.gtmpl
+++ b/extension/portlets/platformNavigation/src/main/webapp/groovy/platformNavigation/portlet/UIUserNavigationPortlet/UIUserNavigationPortlet.gtmpl
@@ -36,9 +36,8 @@
         boolean isOwner=  uicomponent.isProfileOwner();       
         for (node in uicomponent.getUserNodesAsList()) {
             def nodeLabel;
-            def str="UIUserNavigationPortlet.label."+node;
-            if (isOwner) str="UIUserNavigationPortlet.label.My"+node;
-            else   str="UIUserNavigationPortlet.label."+node;
+            def str="UIUserNavigationPortlet.label.My"+node;
+            if ((!isOwner) && (!node.equals(uicomponent.DASHBOARD_URI))) str="UIUserNavigationPortlet.label."+node;
             nodeLabel = _ctx.appRes(str);
             pageURL = urlList[i];
             def navigationTabClass = "";

--- a/extension/portlets/platformNavigation/src/main/webapp/groovy/platformNavigation/portlet/UIUserPlatformToolBarPortlet/UIUserPlatformToolBarPortlet.gtmpl
+++ b/extension/portlets/platformNavigation/src/main/webapp/groovy/platformNavigation/portlet/UIUserPlatformToolBarPortlet/UIUserPlatformToolBarPortlet.gtmpl
@@ -39,7 +39,6 @@
     def labelActivities = _ctx.appRes("UIUserPlatformToolBarPortlet.label.activities");
     def labelProfile = _ctx.appRes("UIUserPlatformToolBarPortlet.label.profile");
     def labelnetwork = _ctx.appRes("UIUserPlatformToolBarPortlet.label.network");
-    def labelpeople = _ctx.appRes("UIUserPlatformToolBarPortlet.label.find");
     def labelaccount = _ctx.appRes("UIUserPlatformToolBarPortlet.label.account");
     def labellanguage = _ctx.appRes("UIUserPlatformToolBarPortlet.label.language");
     def labellogout = _ctx.appRes("UIUserPlatformToolBarPortlet.label.logout");


### PR DESCRIPTION
Fix description
- Remove the redundant variable of UIUserPlatformToolBarPortlet.label.find
- Update the condition to not create UIUserNavigationPortlet.label.dashboard.
