### PR TITLE
PLF-5134 | GettingStarted Portlet : Can not load task list

### DIFF
--- a/extension/portlets/homepagePortlets/src/main/java/org/exoplatform/platform/portlet/juzu/gettingstarted/GettingStarted.java
+++ b/extension/portlets/homepagePortlets/src/main/java/org/exoplatform/platform/portlet/juzu/gettingstarted/GettingStarted.java
@@ -195,7 +195,7 @@ public class GettingStarted {
             parameters.put(GettingStartedUtils.WIDTH, new Integer((Math.round((200 * progress) / 100))).toString());
             parameters.put(GettingStartedUtils.STATUS, status);
             parameters.put(GettingStartedUtils.SHOW, Isshow.toString());
-            if ((isChange) || (reload.equals("true"))) {
+            if ((isChange) || ("true".equals(reload))) {
                 gettingStartedList.render(parameters);
             }
         } catch (Exception E) {


### PR DESCRIPTION
- Problem Analysis:
  A NPE is thrown when the `reload` argument of below method is `null`

```
org.exoplatform.platform.portlet.juzu.gettingstarted.GettingStarted#getGsList
```
- Fix description:
  Use a reverse equals check on the string parameter to avoid calling it on a null variable.
