### PR TITLE
PLF-5833 | RightToLeft mode is not activated when selecting Arabic langu...

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -75,6 +75,7 @@
     <output-encoding>UTF-8</output-encoding>
     <input-encoding>UTF-8</input-encoding>
     <description>Default configuration for the arabe locale</description>
+    <orientation>rt</orientation>
   </locale-config> 
 
   <locale-config>


### PR DESCRIPTION
...age

**Problem analysis:**
- Orientation mode is not set correctly for Arabic language.

**Fix Description:**
- Set RightToLeft (`rt`) mode for Arabic language.
