### PR TITLE
PLF-6123: [watch ECMS document] Missing email content

### DIFF
--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -423,7 +423,7 @@ gatein.ecms.watchdocument.subject=${exo.ecms.watchdocument.subject:Your watching
 # Watch document content mimetype
 gatein.ecms.watchdocument.mimetype=${exo.ecms.watchdocument.mimetype:text/html}
 # Watch document content
-gatein.ecms.watchdocument.content=${exo.ecms.watchdocument.content:<![CDATA[Dear $user_name,<br><br>The document $doc_name ($doc_title) has changed.<br><br>Please go to <a href="$doc_url">$doc_title</a> to see this change.<br><br>]]>}  
+gatein.ecms.watchdocument.content=${exo.ecms.watchdocument.content:Dear $user_name,<br><br>The document $doc_name ($doc_title) has changed.<br><br>Please go to <a href="$doc_url">$doc_title</a> to see this change.<br><br>}  
 
 # Predefined groups or users for lock administrator 
 wcm.lock.admin=${exo.wcm.lock.admin:*:/platform/administrators}

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -447,7 +447,7 @@
 # Watch document content mimetype
 #exo.ecms.watchdocument.mimetype=text/html
 # Watch document content
-#exo.ecms.watchdocument.content=<![CDATA[Dear $user_name,<br><br>The document $doc_name ($doc_title) has changed.<br><br>Please go to <a href="$doc_url">$doc_title</a> to see this change.<br><br>]]>
+#exo.ecms.watchdocument.content=Dear $user_name,<br><br>The document $doc_name ($doc_title) has changed.<br><br>Please go to <a href="$doc_url">$doc_title</a> to see this change.<br><br>
 
 # Predefined groups or users for lock administrator 
 #exo.wcm.lock.admin=*:/platform/administrators


### PR DESCRIPTION
Fix description: change exo.ecms.watchdocument.content variable in configuration file to get expected mail content
