### PR TITLE
PLF-6156: UpgradeProductInfoNodePlugin does not work if ProductInfo node...

### DIFF
--- a/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/UpgradeProductInfoNodePlugin.java
+++ b/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/UpgradeProductInfoNodePlugin.java
@@ -90,6 +90,9 @@ public class UpgradeProductInfoNodePlugin extends UpgradeProductPlugin {
       Node productVersionDeclarationNode = applicationDataNode.getNode(UPGRADE_PRODUCT_SERVICE_NODE_NAME + "/"
           + PRODUCT_VERSION_DECLARATION_NODE_NAME);
       ExtendedNode extendedNode = (ExtendedNode)productVersionDeclarationNode;
+      if (!extendedNode.isCheckedOut()) {
+        extendedNode.checkout();
+      }
       if (extendedNode.canAddMixin("exo:privilegeable")) {
         extendedNode.addMixin("exo:privilegeable");
       }


### PR DESCRIPTION
... is checked-in

Problem analysis
- Checked-in node can not be modified even node in system session.

Fix description
- Check-out Product Info node before updating its permission
