### PR TITLE
PLF-6394: Update configuration.properties and exo-sample.properties

### DIFF
--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -47,15 +47,15 @@ exo.super.user=${exo.super.user:root}
 #
 
 # Email display in "from" field of emails sent by eXo platform.
-gatein.email.smtp.from=${exo.email.smtp.from:noreply@exoplatform.com}
+gatein.email.smtp.from=${exo.email.smtp.from:}
 # SMTP Server hostname.
-gatein.email.smtp.host=${exo.email.smtp.host:localhost}
+gatein.email.smtp.host=${exo.email.smtp.host:}
 # SMTP Server port.
-gatein.email.smtp.port=${exo.email.smtp.port:25}
+gatein.email.smtp.port=${exo.email.smtp.port:}
 # True to enable the secure (TLS) SMTP. See RFC 3207.
 gatein.email.smtp.starttls.enable=${exo.email.smtp.starttls.enable:false}
 # True to enable the SMTP authentication.
-gatein.email.smtp.auth=${exo.email.smtp.auth:false}
+gatein.email.smtp.auth=${exo.email.smtp.auth:}
 # Username to send for authentication.
 gatein.email.smtp.username=${exo.email.smtp.username:}
 # Password to send for authentication.

--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -619,9 +619,6 @@ exo.remote-edit.powerpoint.ico=${exo.remote-edit.powerpoint.ico:uiIcon16x16appli
 exo.calendar.default.event.suggest=${exo.calendar.default.event.suggest:2}
 # auto suggest the end of task time to 30 minutes (1 x 30 min)
 exo.calendar.default.task.suggest=${exo.calendar.default.task.suggest:1}
-# remote calendar synchronization job period (in millisecond)
-# Default : 7200000 (2h)
-exo.calendar.remote.synchronization.job.period=${exo.calendar.remote.synchronization.job.period:7200000}
 
 ###########################
 #

--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -112,10 +112,6 @@ search.excluded-characters=${exo.unified-search.excluded-characters:.-}
 # Notifications
 #
 
-# The period in seconds between two executions of the job
-conf.notification.service.QueueMessage.period=${exo.notification.service.QueueMessage.period:60}
-# Max number of mails to send in the configured period of time
-conf.notification.service.QueueMessage.numberOfMailPerBatch=${exo.notification.service.QueueMessage.numberOfMailPerBatch:30}
 # Portal's name display in "from" field of email notification.
 exo.notifications.portalname=${exo.notification.portalname:eXo}
 

--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -112,6 +112,10 @@ search.excluded-characters=${exo.unified-search.excluded-characters:.-}
 # Notifications
 #
 
+# The period in seconds between two executions of the job
+conf.notification.service.QueueMessage.period=${exo.notification.service.QueueMessage.period:60}
+# Max number of mails to send in the configured period of time
+conf.notification.service.QueueMessage.numberOfMailPerBatch=${exo.notification.service.QueueMessage.numberOfMailPerBatch:30}
 # Portal's name display in "from" field of email notification.
 exo.notifications.portalname=${exo.notification.portalname:eXo}
 

--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -112,10 +112,6 @@ search.excluded-characters=${exo.unified-search.excluded-characters:.-}
 # Notifications
 #
 
-# Configuration of the daily digest email. By default it is sent at 11:30pm (23h30) every day.
-cronJob.notification.NotificationDailyJob.expression=${exo.notification.NotificationDailyJob.expression:0 30 23 ? * *}
-# Configuration of the weekly digest email. By default it is sent at 11:30am (11h30) every Sunday.
-cronJob.notification.NotificationWeeklyJob.expression=${exo.notification.NotificationWeeklyJob.expression:0 30 11 ? * SUN}
 # The period in seconds between two executions of the job
 conf.notification.service.QueueMessage.period=${exo.notification.service.QueueMessage.period:60}
 # Max number of mails to send in the configured period of time

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -135,10 +135,10 @@
 
 # Configuration of the daily and weekly digests Cron Jobs
 # Use the Cron Expression syntax (http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-06)
-# Configuration of the daily digest email. By default it is sent at 11:30pm (23h30) every day.
-#exo.notification.NotificationDailyJob.expression=0 30 23 ? * *
-# Configuration of the weekly digest email. By default it is sent at 11:30am (11h30) every Sunday.
-#exo.notification.NotificationWeeklyJob.expression=0 30 11 ? * SUN
+# Configuration of the daily digest email. By default it is sent at 11:00pm (23h00) every day.
+#exo.notification.NotificationDailyJob.expression=0 0 23 ? * *
+# Configuration of the weekly digest email. By default it is sent at 11:00am (11h00) every Sunday.
+#exo.notification.NotificationWeeklyJob.expression=0 0 11 ? * SUN
 # The period in seconds between two executions of the sendmail job
 #exo.notification.service.QueueMessage.period=60
 # Max number of mails to send in the configured period of time

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -631,9 +631,6 @@
 #exo.calendar.default.event.suggest=2
 # auto suggest the end of task time to 30 minutes (1 x 30 min)
 #exo.calendar.default.task.suggest=1
-# remote calendar synchronization job period (in millisecond)
-# Default : 7200000 (2h)
-#exo.calendar.remote.synchronization.job.period=7200000
 
 ###########################
 #


### PR DESCRIPTION
Fix description: Redundant property "exo.calendar.remote.synchronization.job.period"
Remove exo.calendar.remote.synchronization.job.period from configuration.properties & exo-sample.properties