### PR TITLE
Fix for usernames with special chars. breaks ServerCookie on tomcat

### DIFF
--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthAbstractFilter.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/filter/OAuthAbstractFilter.java
@@ -34,6 +34,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URLEncoder;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
@@ -48,10 +49,10 @@ public abstract class OAuthAbstractFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) request;
         HttpServletResponse res = (HttpServletResponse) response;
-
+        
         if (req.getRemoteUser() != null) {
             // User already loggedIn
-            Cookie cookie = new Cookie(COOKIE_LAST_LOGIN, req.getRemoteUser());
+            Cookie cookie = new Cookie(COOKIE_LAST_LOGIN, URLEncoder.encode(req.getRemoteUser(), "UTF-8"));
             cookie.setPath(req.getContextPath());
             cookie.setMaxAge(3600); // 1 hours = 60 * 60 seconds
             cookie.setHttpOnly(true);

--- a/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
+++ b/component/oauth-auth/src/main/java/org/exoplatform/oauth/service/impl/OAuthRegistrationServicesImpl.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.net.URLDecoder;
 
 public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices {
   private static Logger log = LoggerFactory.getLogger(OAuthRegistrationServicesImpl.class);
@@ -124,13 +125,15 @@ public class OAuthRegistrationServicesImpl implements OAuthRegistrationServices 
         if (foundUser == null && cookies != null && cookies.length > 0) {
           for (Cookie cookie : cookies) {
             if (OAuthAbstractFilter.COOKIE_LAST_LOGIN.equals(cookie.getName())) {
-              username = cookie.getValue();
-              if(username != null && username.length() > 0) {
-                query = new Query();
-                query.setUserName(username);
-                users = userHandler.findUsersByQuery(query, UserStatus.ANY);
-                if(users != null && users.getSize() > 0) {
-                  foundUser = users.load(0, 1)[0];
+              if (cookie.getValue() != null) {
+                username = URLDecoder.decode(cookie.getValue(), "UTF-8");
+                if (username.length() > 0) {
+                  query = new Query();
+                  query.setUserName(username);
+                  users = userHandler.findUsersByQuery(query, UserStatus.ANY);
+                  if(users != null && users.getSize() > 0) {
+                    foundUser = users.load(0, 1)[0];
+                  }
                 }
               }
               break;


### PR DESCRIPTION
Upgrading Tomcat to 7.0.63 on PLF 4.3.1 and higher breaks Cookies for user with special characters in their username.

Tomcat ServerCookie handler complains about a control character present in the cookie value  (username in this case)

This PR URLEncodes the username and URLDecode's it to prevent this error and make eXo's username cookie process compatible with Tomcat 7.0.63+
