### PR TITLE
PLF-6815 Make listing the connected users async

### DIFF
--- a/extension/portlets/homepagePortlets/src/main/java/org/exoplatform/platform/portlet/juzu/whoisonline/WhoIsOnLineController.java
+++ b/extension/portlets/homepagePortlets/src/main/java/org/exoplatform/platform/portlet/juzu/whoisonline/WhoIsOnLineController.java
@@ -35,20 +35,11 @@ public class WhoIsOnLineController {
     @View
     public Response.Content index() {
         try {
-
-            String userId = RequestContext.getCurrentInstance().getRemoteUser();
-            List<User> friends = whoIsOnline.getFriends(userId);
-            if (friends == null) {
-                friends = new ArrayList<User>();
-                LOG.info("No  logged user | WhoIsOnLin Portlet will not be displayed");
-            }
-            return index.with().set("users", friends).ok();
-
+            return index.with().set("users", new ArrayList<User>()).ok();
         } catch (Exception e) {
             LOG.error("Error while rendering WhoIsOnLine Portlet :" + e.getMessage(), e);
             return index.with().set("users", new ArrayList<User>()).ok();
         }
-
     }
 
     @Ajax


### PR DESCRIPTION
Make listing the connected users not blocker for the first page display
 The index method will be used in first page display process. By deleting its content, it will avoid getting the list of connected users on first display.
