### PR TITLE
[PLF-7759] java.util.MissingResourceException when we click on notifi…

### DIFF
--- a/extension/portlets/platformNavigation/src/main/java/org/exoplatform/platform/component/UINotificationPopoverToolbarPortlet.java
+++ b/extension/portlets/platformNavigation/src/main/java/org/exoplatform/platform/component/UINotificationPopoverToolbarPortlet.java
@@ -110,7 +110,6 @@ public class UINotificationPopoverToolbarPortlet extends UIPortletApplication {
         JSONObject object = new JSONObject();
         object.put("notifications", sb.toString());
         object.put("showViewAll", hasNotifications());
-        object.put("inlineImageLabel", context.getApplicationResourceBundle().getString("UINotificationPopoverToolbarPortlet.label.InlineImage"));
         //
         res.getWriter().write(object.toString());
         return;


### PR DESCRIPTION
…cation icon

fix description : 

- remove the line "object.put("inlineImageLabel", context.getApplicationResourceBundle().getString("UINotificationPopoverToolbarPortlet.label.InlineImage"));" which is added for fix this issue https://github.com/exoplatform/platform/commit/66fd834af7017a9b769d44e9b29edf713ccd6134#diff-1eacd3c058cb8b56818fdbde308eef3f in PLF 5.0 version.