### PR TITLE
PLF-8298 : fix syntax error while converting from MySQL to PostgreSQL

### DIFF
--- a/exo-gadget-pack/gadget-pack-services/src/main/resources/db/changelog/loginhistory.db.changelog-1.0.0.xml
+++ b/exo-gadget-pack/gadget-pack-services/src/main/resources/db/changelog/loginhistory.db.changelog-1.0.0.xml
@@ -17,7 +17,7 @@
     <!-- Login History -->
     <changeSet author="LoginHistory" id="1.0.0-1">
         <createTable tableName="LOGIN_HISTORY">
-            <column name="ID" type="BIGINT(20)" autoIncrement="${autoIncrement}" startWith="1">
+            <column name="ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="PK_LOGIN_HISTORY"/>
             </column>
             <column name="USER_ID" type="VARCHAR(255)">


### PR DESCRIPTION
Delete the BIGINT type's size in order to avoid syntax error while converting the Changeset for creating the database table LOGIN_HISTORY, from MySQL to PostgreSQL.