### PR TITLE
 PLF-8447 : "Send me a digest email" on notification settings is not working

### DIFF
--- a/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
+++ b/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
@@ -1,0 +1,38 @@
+package org.exoplatform.platform.upgrade.plugins;
+
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.version.util.VersionComparator;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.scheduler.JobSchedulerService;
+
+public class ResumeDigestJobUpgradePlugin extends UpgradeProductPlugin {
+
+  private JobSchedulerService schedulerService;
+
+  private static final Log LOG = ExoLogger.getLogger(ResumeDigestJobUpgradePlugin.class);
+
+
+  public ResumeDigestJobUpgradePlugin(JobSchedulerService schedulerService, InitParams initParams) {
+    super(initParams);
+    this.schedulerService = schedulerService;
+  }
+
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    try {
+      schedulerService.resumeJob("NotificationDailyJob", "Notification");
+      schedulerService.resumeJob("NotificationWeeklyJob", "Notification");
+    } catch (Exception e) {
+      LOG.error("Error when resuming daily and weekly job",e);
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion, String previousVersion) {
+    return VersionComparator.isAfter(newVersion, previousVersion);
+  }
+
+}

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
@@ -768,7 +768,7 @@
            <value-param>
                <name>plugin.upgrade.target.version</name>
                <description>Target version of the plugin</description>
-               <value>5.3.0</value>
+               <value>6.0.0</value>
            </value-param>
        </init-params>
      </component-plugin>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
@@ -642,5 +642,136 @@
          </value-param>
        </init-params>
      </component-plugin>
+<<<<<<< HEAD
+=======
+
+     <component-plugin>
+       <name>UpgradeMigrateGadgetToPortlet</name>
+       <set-method>addUpgradePlugin</set-method>
+       <type>org.exoplatform.platform.upgrade.plugins.UpgradeGadgetToPortletPlugin</type>
+       <description>Migrate gadget to portlet or drop the unsupported ones</description>
+       <init-params>
+         <value-param>
+           <name>product.group.id</name>
+           <description>The groupId of the product</description>
+           <value>org.exoplatform.platform</value>
+         </value-param>
+         <value-param>
+           <name>plugin.execution.order</name>
+           <description>The plugin execution order</description>
+           <value>3</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.execute.once</name>
+           <description>Execute this upgrade plugin only once</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.async.execution</name>
+           <description>Execute the upgrade plugin asynchronously</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.target.version</name>
+           <description>Target version of the plugin</description>
+           <value>5.3.0</value>
+         </value-param>
+       </init-params>
+     </component-plugin>
+     <component-plugin>
+       <name>UpgradeRemoveGadgetPlugin</name>
+       <set-method>addUpgradePlugin</set-method>
+       <type>org.exoplatform.platform.upgrade.plugins.UpgradeRemoveGadgetPlugin</type>
+       <description>Drop gadget support</description>
+       <init-params>
+         <value-param>
+           <name>product.group.id</name>
+           <description>The groupId of the product</description>
+           <value>org.exoplatform.platform</value>
+         </value-param>
+         <value-param>
+           <name>plugin.execution.order</name>
+           <description>The plugin execution order</description>
+           <value>5</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.execute.once</name>
+           <description>Execute this upgrade plugin only once</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.async.execution</name>
+           <description>Execute the upgrade plugin asynchronously</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.target.version</name>
+           <description>Target version of the plugin</description>
+           <value>5.3.0</value>
+         </value-param>
+       </init-params>
+     </component-plugin>
+     <component-plugin>
+       <name>UpgradeRemoveUserPagesPlugin</name>
+       <set-method>addUpgradePlugin</set-method>
+       <type>org.exoplatform.platform.upgrade.plugins.UpgradeUserPortalPlugin</type>
+       <description>Drop user pages and navigations</description>
+       <init-params>
+         <value-param>
+           <name>product.group.id</name>
+           <description>The groupId of the product</description>
+           <value>org.exoplatform.platform</value>
+         </value-param>
+         <value-param>
+           <name>plugin.execution.order</name>
+           <description>The plugin execution order</description>
+           <value>4</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.execute.once</name>
+           <description>Execute this upgrade plugin only once</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.async.execution</name>
+           <description>Execute the upgrade plugin asynchronously</description>
+           <value>true</value>
+         </value-param>
+         <value-param>
+           <name>plugin.upgrade.target.version</name>
+           <description>Target version of the plugin</description>
+           <value>5.3.0</value>
+         </value-param>
+       </init-params>
+     </component-plugin>
+     <component-plugin>
+       <name>ResumeDigestJobUpgradePlugin</name>
+       <set-method>addUpgradePlugin</set-method>
+       <type>org.exoplatform.platform.upgrade.plugins.ResumeDigestJobUpgradePlugin</type>
+       <description>Resume the digest notification jobs daily and weekly (deactivated by mail notification migration)</description>
+       <init-params>
+           <value-param>
+               <name>product.group.id</name>
+               <description>The groupId of the product</description>
+               <value>org.exoplatform.platform</value>
+           </value-param>
+           <value-param>
+               <name>plugin.execution.order</name>
+               <description>The plugin execution order</description>
+               <value>2</value>
+           </value-param>
+           <value-param>
+               <name>plugin.upgrade.execute.once</name>
+               <description>Execute this upgrade pluginonly once</description>
+               <value>true</value>
+           </value-param>
+           <value-param>
+               <name>plugin.upgrade.target.version</name>
+               <description>Target version of the plugin</description>
+               <value>5.3.0</value>
+           </value-param>
+       </init-params>
+     </component-plugin>
+>>>>>>> eb4ceb03f8... PLF-8447 : Resume Daily and weekly digest mails jobs (#406)
    </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Prior to this change, digest email are not more sent
In fact, jobs DailyNotificationJob and WeeklyNotification are paused after platform start, without resuming it

Jobs are paused by MailNotificationMigration Upgrade Plugin. In some cases, the resumeJob is missing

This change add the resume in all cases, even if the migration is already done and finished