### PR TITLE
PLF-8447 : "Send me a digest email" on notification settings is not w…

### DIFF
--- a/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
+++ b/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
@@ -1,0 +1,79 @@
+package org.exoplatform.platform.upgrade.plugins;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.service.storage.MailNotificationStorage;
+import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.commons.notification.impl.jpa.email.JPAMailNotificationStorage;
+import org.exoplatform.commons.notification.impl.jpa.email.dao.MailDigestDAO;
+import org.exoplatform.commons.notification.job.NotificationJob;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.commons.version.util.VersionComparator;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.scheduler.JobSchedulerService;
+
+
+/**
+ * Upgrade plugin to resume daily and weekly digest jobs.
+ * This jobs have been paused during migration of notification from JCR to RDBMS
+ * This UP resume both jobs
+ * In addition, if the migration comes from version 5.2.0+, we completly delete stored digest.
+ * In fact, during the time the jobs were paused, the digest were stored in DB.
+ * If we don't delete it, the first start will create old for old digests.
+ *
+ * Finally, if we upgrade from a version before 5.2.0, we don't delete digest :
+ * The jobs were not paused, and there is no "old" digests stored.
+ */
+
+public class ResumeDigestJobUpgradePlugin extends UpgradeProductPlugin {
+
+  private JobSchedulerService schedulerService;
+  private MailNotificationStorage mailNotificationStorage;
+
+  private static final Log LOG = ExoLogger.getLogger(ResumeDigestJobUpgradePlugin.class);
+
+
+  public ResumeDigestJobUpgradePlugin(JobSchedulerService schedulerService, MailNotificationStorage mailNotificationStorage, InitParams initParams) {
+    super(initParams);
+    this.mailNotificationStorage=mailNotificationStorage;
+    this.schedulerService = schedulerService;
+  }
+
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+
+
+    try {
+      //Force remove digest items only source migration version is after 5.2.0
+      //Before this version, there is no problem of blocking digest, so no need of delete it
+      if (VersionComparator.isAfter(oldVersion, "5.2.0") ||
+              VersionComparator.isSame(oldVersion, "5.2.0")) {
+        NotificationContext context = NotificationContextImpl.cloneInstance();
+
+        //force remove weekly notification digest
+        context.append(NotificationJob.JOB_DAILY, false);
+        context.append(NotificationJob.JOB_WEEKLY, true);
+        mailNotificationStorage.removeMessageAfterSent(context);
+
+        //force remove daily notification digest
+        context.append(NotificationJob.JOB_WEEKLY, false);
+        context.append(NotificationJob.JOB_DAILY, true);
+        mailNotificationStorage.removeMessageAfterSent(context);
+      }
+
+      schedulerService.resumeJob("NotificationDailyJob", "Notification");
+      schedulerService.resumeJob("NotificationWeeklyJob", "Notification");
+    } catch (Exception e) {
+      LOG.error("Error when resuming daily and weekly job",e);
+      throw new RuntimeException("An error occurred when resuming daily and weekly job");
+    }
+  }
+
+  @Override
+  public boolean shouldProceedToUpgrade(String newVersion, String previousVersion) {
+    return VersionComparator.isAfter(newVersion, previousVersion);
+  }
+
+}

--- a/component/upgrade/plugins/src/test/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePluginTest.java
+++ b/component/upgrade/plugins/src/test/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePluginTest.java
@@ -1,0 +1,60 @@
+package org.exoplatform.platform.upgrade.plugins;
+
+import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.commons.api.notification.service.storage.MailNotificationStorage;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.scheduler.JobSchedulerService;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class ResumeDigestJobUpgradePluginTest {
+
+    @Test
+    public void testResumeDigestJobUpgradePluginFrom510To520() throws Exception {
+        //Given
+        JobSchedulerService schedulerService = mock(JobSchedulerService.class);
+        MailNotificationStorage mailNotificationStorage = mock(MailNotificationStorage.class);
+
+        // When
+        ResumeDigestJobUpgradePlugin plugin = new ResumeDigestJobUpgradePlugin(schedulerService,
+                mailNotificationStorage, new InitParams());
+        plugin.processUpgrade("5.1.0", "5.2.0");
+
+        // Then
+        verify(mailNotificationStorage, times(0)).removeMessageAfterSent(any(NotificationContext.class));
+        verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
+    }
+
+    @Test
+    public void testResumeDigestJobUpgradePluginFrom520To600() throws Exception {
+        //Given
+        JobSchedulerService schedulerService = mock(JobSchedulerService.class);
+        MailNotificationStorage mailNotificationStorage = mock(MailNotificationStorage.class);
+
+        // When
+        ResumeDigestJobUpgradePlugin plugin = new ResumeDigestJobUpgradePlugin(schedulerService,
+                mailNotificationStorage, new InitParams());
+        plugin.processUpgrade("5.2.0", "6.0.0");
+
+        // Then
+        verify(mailNotificationStorage, times(2)).removeMessageAfterSent(any(NotificationContext.class));
+        verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
+    }
+
+    @Test
+    public void testResumeDigestJobUpgradePluginFrom510To600() throws Exception {
+        //Given
+        JobSchedulerService schedulerService = mock(JobSchedulerService.class);
+        MailNotificationStorage mailNotificationStorage = mock(MailNotificationStorage.class);
+
+        // When
+        ResumeDigestJobUpgradePlugin plugin = new ResumeDigestJobUpgradePlugin(schedulerService,
+                mailNotificationStorage, new InitParams());
+        plugin.processUpgrade("5.1.0", "6.0.0");
+
+        // Then
+        verify(mailNotificationStorage, times(0)).removeMessageAfterSent(any(NotificationContext.class));
+        verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
+    }
+}

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/upgrade/upgrade-configuration.xml
@@ -609,5 +609,33 @@
          </value-param>
        </init-params>
      </component-plugin>
+     <component-plugin>
+       <name>ResumeDigestJobUpgradePlugin</name>
+       <set-method>addUpgradePlugin</set-method>
+       <type>org.exoplatform.platform.upgrade.plugins.ResumeDigestJobUpgradePlugin</type>
+       <description>Resume the digest notification jobs daily and weekly (deactivated by mail notification migration)</description>
+       <init-params>
+           <value-param>
+               <name>product.group.id</name>
+               <description>The groupId of the product</description>
+               <value>org.exoplatform.platform</value>
+           </value-param>
+           <value-param>
+               <name>plugin.execution.order</name>
+               <description>The plugin execution order</description>
+               <value>2</value>
+           </value-param>
+           <value-param>
+               <name>plugin.upgrade.execute.once</name>
+               <description>Execute this upgrade pluginonly once</description>
+               <value>true</value>
+           </value-param>
+           <value-param>
+               <name>plugin.upgrade.target.version</name>
+               <description>Target version of the plugin</description>
+               <value>6.0.0</value>
+           </value-param>
+       </init-params>
+     </component-plugin>
    </external-component-plugins>
 </configuration>


### PR DESCRIPTION
…orking (#412)

* PLF-8447 : Resume Daily and weekly digest mails jobs (#406)

* PLF-8447 : Resume Daily and weekly digest mails jobs

This commit add an upgrade plugin to resume jobs in environments in which the migration is already done.

* PLF-8447 : Resume Daily and weekly digest mails jobs

Before this fix, the Upgrade Plugin was not launched if the platform is already in version 6.0
In fact, for tribe, this plugin will be not launched.

The fix change the target version for the UP so that it will be started also on 6.0.x

* PLF-8447 : Send Digest mail are not working
Before this fix, when the Upgrade Plugin is applied after a lot af weeks without running,
all pending notification will be treated and sent.
This Fix remove all daily and weekly notifications which are pending.

* Use MailNotificationStorage instead of DAO

* PLF-8447 : manage error. If an error occurs, throw it to relaunch the UP at next startup

* PLF-8447 : limit the digest to version after 5.2.0

* PLF-8447 : the delete digest must be run if oldVersion is 5.2.0

* Update exception management

* Add unit test

* Update file headers