### PR TITLE
PLF-8590 Enhance CSRF check parameter in URL (#414)

### DIFF
--- a/extension/portlets/platformNavigation/src/main/webapp/javascript/eXo/platform/navigation/Notification/NotificationPopover.js
+++ b/extension/portlets/platformNavigation/src/main/webapp/javascript/eXo/platform/navigation/Notification/NotificationPopover.js
@@ -243,7 +243,7 @@
       },
       appendCSRFToken : function(url) {
         url.indexOf('?') >= 0 ? url += '&' : url += '?';
-        url += 'gtn:csrf=' + eXo.env.portal.csrfToken;
+        url += 'portal:csrf=' + eXo.env.portal.csrfToken;
         return url;
       },
       markAllRead : function() {


### PR DESCRIPTION
This modification applies new CSRF parameter naming that will avoid confusion made with '&gtn:csrf' that is converted into '>n:csrf' in some conditions