### PR TITLE
PLF-8216-01: Remove property for exo.ecms.watchdocument.sender

### DIFF
--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -546,8 +546,6 @@ wcm.search.enableFuzzySearch=${exo.ecms.search.enableFuzzySearch:true}
 # Site search fuzzy index
 wcm.search.fuzzySearchIndex=${exo.ecms.search.fuzzySearchIndex:0.8}
 #
-# Watch document sender
-gatein.ecms.watchdocument.sender=${exo.ecms.watchdocument.sender:support@exoplatform.com}
 # Watch document subject
 gatein.ecms.watchdocument.subject=${exo.ecms.watchdocument.subject:Your watching document is changed}
 # Watch document content mimetype

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -313,8 +313,6 @@
 # Site search fuzzy index
 #exo.ecms.search.fuzzySearchIndex=0.8
 #
-# Watch document sender
-#exo.ecms.watchdocument.sender=support@exoplatform.com
 # Watch document subject
 #exo.ecms.watchdocument.subject=Your watching document is changed
 # Watch document content mimetype


### PR DESCRIPTION
Make sure to set the sender as the exo.email.smtp.from for the watch document set emails.