### PR TITLE
COMMONS-586 (#429)

### DIFF
--- a/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
+++ b/component/upgrade/plugins/src/main/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePlugin.java
@@ -5,6 +5,7 @@ import org.exoplatform.commons.api.notification.service.storage.MailNotification
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.notification.impl.jpa.email.JPAMailNotificationStorage;
 import org.exoplatform.commons.notification.impl.jpa.email.dao.MailDigestDAO;
+import org.exoplatform.commons.notification.impl.jpa.email.entity.MailNotifEntity;
 import org.exoplatform.commons.notification.job.NotificationJob;
 import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.version.util.VersionComparator;
@@ -12,6 +13,9 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.scheduler.JobSchedulerService;
+
+import java.util.Calendar;
+import java.util.List;
 
 
 /**
@@ -51,10 +55,13 @@ public class ResumeDigestJobUpgradePlugin extends UpgradeProductPlugin {
       if (VersionComparator.isAfter(oldVersion, "5.2.0") ||
               VersionComparator.isSame(oldVersion, "5.2.0")) {
         mailNotificationStorage.deleteAllDigests();
+        NotificationContext context = NotificationContextImpl.cloneInstance();
+        mailNotificationStorage.removeMessageAfterSent(context);
       }
 
       schedulerService.resumeJob("NotificationDailyJob", "Notification");
       schedulerService.resumeJob("NotificationWeeklyJob", "Notification");
+
     } catch (Exception e) {
       LOG.error("Error when resuming daily and weekly job",e);
       throw new RuntimeException("An error occurred when resuming daily and weekly job");

--- a/component/upgrade/plugins/src/test/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePluginTest.java
+++ b/component/upgrade/plugins/src/test/java/org/exoplatform/platform/upgrade/plugins/ResumeDigestJobUpgradePluginTest.java
@@ -5,6 +5,8 @@ import org.exoplatform.commons.api.notification.service.storage.MailNotification
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.scheduler.JobSchedulerService;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.matchers.Any;
 
 import static org.mockito.Mockito.*;
 
@@ -23,6 +25,7 @@ public class ResumeDigestJobUpgradePluginTest {
 
         // Then
         verify(mailNotificationStorage, times(0)).deleteAllDigests();
+        verify(mailNotificationStorage, times(0)).removeMessageAfterSent(Mockito.any());
         verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
     }
 
@@ -39,6 +42,7 @@ public class ResumeDigestJobUpgradePluginTest {
 
         // Then
         verify(mailNotificationStorage, times(1)).deleteAllDigests();
+        verify(mailNotificationStorage, times(1)).removeMessageAfterSent(Mockito.any());
         verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
     }
 
@@ -55,6 +59,7 @@ public class ResumeDigestJobUpgradePluginTest {
 
         // Then
         verify(mailNotificationStorage, times(0)).deleteAllDigests();
+        verify(mailNotificationStorage, times(0)).removeMessageAfterSent(Mockito.any());
         verify(schedulerService,times(2)).resumeJob(anyString(),anyString());
     }
 }


### PR DESCRIPTION
After 5.2.4->5.3.0 migration daily and weekly jobs are restarted at same time due to long time without execution.
The 2 jobs try to clean notifs and notif params without digest.
As we are clean digest in ResumeDigestJobupgradePlugin, there are a lot of row to delete, and job are in conflict and generate a transaction exception

This change add the notification clean up before resume the jobs, and after deleting digest if necessary.
So When Job are executed, they read tables, find no rows, and exited, without error.