### PR TITLE
MAINT-26434: Add i18n for search administration page

### DIFF
--- a/component/common/src/main/resources/conf/portal/setup-navigation.xml
+++ b/component/common/src/main/resources/conf/portal/setup-navigation.xml
@@ -108,7 +108,7 @@
         <node>
             <uri>searchIndexing</uri>
             <name>searchIndexing</name>
-            <label>Search Indexing</label>
+            <label>#{UISetupPlatformToolBarPortlet.label.searchIndexing}</label>
             <page-reference>group::/platform/administrators::searchIndexing</page-reference>
         </node>
     </page-nodes>

--- a/extension/webapp/src/main/resources/locale/navigation/group/platform/administrators_en.properties
+++ b/extension/webapp/src/main/resources/locale/navigation/group/platform/administrators_en.properties
@@ -29,3 +29,4 @@ administration.Branding=Branding
 administration.search=Search
 administration.notification=Notification
 administration.spaces=Spaces Management
+administration.searchIndexing=Search Indexing

--- a/extension/webapp/src/main/resources/locale/navigation/group/platform/administrators_uk.properties
+++ b/extension/webapp/src/main/resources/locale/navigation/group/platform/administrators_uk.properties
@@ -29,3 +29,5 @@ administration.Branding=\u0424\u0456\u0440\u043C\u043E\u0432\u0430 \u0441\u0438\
 administration.search=\u041F\u043E\u0448\u0443\u043A
 administration.notification=Notification
 administration.spaces=Spaces Management
+administration.searchIndexing=\u041f\u043e\u0448\u0443\u043a \u0028\u0423\u043f\u0440\u0430\u0432\u043b\u0456\u043d\u043d\u044f\u0029 \u0456\u043d\u0434\u0435\u043a\u0441\u0456\u0432
+

--- a/extension/webapp/src/main/resources/locale/platform/UISetupPlatformToolBarPortlet_en.xml
+++ b/extension/webapp/src/main/resources/locale/platform/UISetupPlatformToolBarPortlet_en.xml
@@ -20,6 +20,7 @@
       <Notification>Notifications</Notification>
 <ide>IDE</ide>
 <search>Search Administration</search>
+<searchIndexing>Search Indexing</searchIndexing>
 </label>
 </UISetupPlatformToolBarPortlet>
 </bundle>

--- a/extension/webapp/src/main/resources/locale/platform/UISetupPlatformToolBarPortlet_uk.xml
+++ b/extension/webapp/src/main/resources/locale/platform/UISetupPlatformToolBarPortlet_uk.xml
@@ -20,6 +20,7 @@
       <Notification>Сповіщення</Notification>
 <ide>IDE</ide>
 <search>Адміністрування пошуку</search>
+<searchIndexing>Пошук (Управління) індексів</searchIndexing>
 </label>
 </UISetupPlatformToolBarPortlet>
 </bundle>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/navigation.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/navigation.xml
@@ -97,7 +97,7 @@
         <node>
             <uri>searchIndexing</uri>
             <name>searchIndexing</name>
-            <label>Search Indexing</label>
+            <label>#{administration.searchIndexing}</label>
             <page-reference>group::/platform/administrators::searchIndexing</page-reference>
         </node>
     </page-nodes>


### PR DESCRIPTION
Add i18n for the page Search Administration, this page was removed for eXo platform 6.0 thus this PR does not need porting on that version