### PR TITLE
Allow to override hibernate.hbm2ddl.auto property

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -44,7 +44,7 @@
       <properties-param>
         <name>hibernate.properties</name>
         <description>Default Hibernate Service</description>
-        <property name="hibernate.hbm2ddl.auto" value="update"/>
+        <property name="hibernate.hbm2ddl.auto" value="${exo.idm.hibernate.hbm2ddl:update}"/>
         <property name="hibernate.show_sql" value="false" />
         <property name="hibernate.connection.datasource" value="${gatein.idm.datasource.name}${container.name.suffix}" />
         <property name="hibernate.connection.autocommit" value="false" />


### PR DESCRIPTION
As suggested in @boubaker  [PR](https://github.com/exoplatform/gatein-portal/commit/16b178c79bfbc9f7d232ebf636da528eccf47093) :`hibernate.hbm2ddl.auto` should be set to `none`, thus we define a property to allow turn off DB schema update in production
